### PR TITLE
Bottom icon click, mouse over, improvement

### DIFF
--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-client/src/main/java/org/kie/workbench/common/stunner/sw/client/shapes/icons/BottomDepiction.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-client/src/main/java/org/kie/workbench/common/stunner/sw/client/shapes/icons/BottomDepiction.java
@@ -20,11 +20,14 @@ import com.ait.lienzo.client.core.shape.Group;
 import com.ait.lienzo.client.core.shape.MultiPath;
 import com.ait.lienzo.client.core.shape.Rectangle;
 import com.ait.lienzo.client.core.types.Point2D;
+import com.ait.lienzo.tools.client.event.HandlerRegistration;
 
 import static org.kie.workbench.common.stunner.sw.client.shapes.StateShapeView.STATE_SHAPE_HEIGHT;
 import static org.kie.workbench.common.stunner.sw.client.shapes.StateShapeView.STATE_SHAPE_WIDTH;
 
 public class BottomDepiction extends Group {
+
+    private final HandlerRegistration mouseClickHandler;
 
     public BottomDepiction(String icon) {
         setLocation(new Point2D(STATE_SHAPE_WIDTH / 2 - 8, STATE_SHAPE_HEIGHT - 20));
@@ -44,5 +47,15 @@ public class BottomDepiction extends Group {
                 .setFillColor("#4F5255")
                 .setListening(false);
         add(multiPath);
+
+        mouseClickHandler = border.addNodeMouseClickHandler(
+                event -> this.getParent().asGroup().getChildren().get(0).fireEvent(event)
+        );
+    }
+
+    @Override
+    public void destroy() {
+        super.destroy();
+        mouseClickHandler.removeHandler();
     }
 }

--- a/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-client/src/main/java/org/kie/workbench/common/stunner/sw/client/shapes/icons/CornerIcon.java
+++ b/packages/serverless-workflow-diagram-editor/sw-editor/sw-editor-client/src/main/java/org/kie/workbench/common/stunner/sw/client/shapes/icons/CornerIcon.java
@@ -53,10 +53,9 @@ public class CornerIcon extends Group {
         add(clockIcon);
 
         mouseEnterHandler = border.addNodeMouseEnterHandler(event -> {
-            this.getParent().moveToTop();
-            this.moveToTop();
             createToolTip();
             clockIcon.setFillColor("#4F5255");
+            border.getLayer().batch();
         });
         mouseExitHandler = border.addNodeMouseExitHandler(event -> {
             tooltipElement.destroy();
@@ -77,7 +76,7 @@ public class CornerIcon extends Group {
         });
         final Layer topLayer = getLayer().getScene().getTopLayer();
         topLayer.add(tooltipElement.asPrimitive());
-        tooltipElement.offset(() -> CornerIcon.this.getComputedLocation());
+        tooltipElement.offset(CornerIcon.this::getComputedLocation);
         tooltipElement.forComputedBoundingBox(border::getBoundingBox);
         tooltipElement.show();
     }


### PR DESCRIPTION
Hello @romartin,

there are fixes for:

* revert onclick deletion of Bottom depiction
* Fix for mouse over for icons (didn't apply on hover color of the icon)
* removed some "moveToTop" which are not relevant anymore after you improved tooltip alignment.

Thank you!